### PR TITLE
refactor: 로그인 페이지 UI 개선

### DIFF
--- a/src/hooks/useLoginMutation.ts
+++ b/src/hooks/useLoginMutation.ts
@@ -9,10 +9,10 @@ const useLoginMutation = () => {
 
   const loginMutation = useMutation({
     mutationFn: postLogin,
-    onSuccess: ({ needSignup, accessToken }, requestDto) => {
+    onSuccess: ({ data: { needSignup, user, accessToken } }, requestDto) => {
       if (needSignup) {
         navigate(ROUTE_URL_FULL.SIGNUP, {
-          state: requestDto,
+          state: { requestDto, user },
         });
         return;
       }

--- a/src/pages/OauthRedirect.tsx
+++ b/src/pages/OauthRedirect.tsx
@@ -11,6 +11,7 @@ const OauthRedirect = () => {
 
   const code = searchParams.get('code');
   const error = searchParams.get('error');
+  const state = searchParams.get('state');
 
   if (error || !code || !isAuthProvider(provider)) {
     throw new Error('로그인에 실패했습니다.');
@@ -19,8 +20,12 @@ const OauthRedirect = () => {
   const { mutateLogin } = useLoginMutation();
 
   useEffect(() => {
-    mutateLogin({ provider, authorizationCode: code });
-  }, [code, provider, mutateLogin]);
+    mutateLogin({
+      provider,
+      authorizationCode: code,
+      state: state ? state : undefined,
+    });
+  }, [code, provider, state, mutateLogin]);
 
   return <div className={LOGIN_STYLE.loading}>로그인 중입니다</div>;
 };

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -3,4 +3,5 @@ export type ProviderType = 'kakao' | 'naver' | 'google';
 export type LoginRequestDto = {
   provider: ProviderType;
   authorizationCode: string;
+  state?: string;
 };


### PR DESCRIPTION
## 요약
- 네이버 로그인 시 요청 바디에 state 추가
- 로그인 응답 포맷 개선

Close #27 

## 변경 사항

- 회원가입 필요시 아래와 같이 데이터를 응답합니다.
  ```json
  "data": {
    "needSignup": true,
    "user": {
      "email": "user@example.com"
    }
  }
  ```
- 로그인 성공 시 아래와 같이 데이터를 응답합니다.
  ```json
  "data": {
    "needSignup": false,
    "accessToken": "access-token"
  }
  ```
  

## 체크리스트

- [ ] 이해하기 어려운 코드에는 주석을 추가했습니다  
- [ ] 관련 문서를 수정했습니다  
- [x] 새로운 경고가 발생하지 않습니다  
- [ ] 수정한 기능 또는 추가한 기능에 대해 테스트를 작성했습니다  
- [x] 의존성 있는 변경 사항이 병합 및 배포되었습니다

## 관련 이슈

- #27 

## 리뷰 반영 사항

<!-- PR리뷰 반형 사항 -->

<details>
<summary><strong>선택 항목 펼치기</strong></summary>

## 스크린샷

<!-- 시각적인 변경 사항이 있다면 스크린샷이나 GIF를 포함해 주세요. 리뷰어가 쉽게 이해할 수 있습니다. -->

## 테스트 방법

<!-- PR에서 수행한 변경 사항을 어떻게 테스트할 수 있는지 설명해 주세요. 리뷰어가 직접 확인할 수 있도록 돕습니다. -->

## 리뷰어 참고사항

<!-- 리뷰어에게 특별히 알려야 할 사항이나 고려할 점이 있다면 여기에 작성해 주세요. -->

</details>