### PR TITLE
 feature: #50-프론트앤드_CI/CD_구축

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy to Beanstalk
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+          VITE_KAKAO_CLIENT_ID: ${{ secrets.VITE_KAKAO_CLIENT_ID }}
+          VITE_KAKAO_REDIRECT_URI: ${{ secrets.VITE_KAKAO_REDIRECT_URI }}
+          VITE_NAVER_CLIENT_ID: ${{ secrets.VITE_NAVER_CLIENT_ID }}
+          VITE_NAVER_REDIRECT_URI: ${{ secrets.VITE_NAVER_REDIRECT_URI }}
+          VITE_NAVER_STATE: ${{ secrets.VITE_NAVER_STATE }}
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
+          VITE_GOOGLE_REDIRECT_URI: ${{ secrets.VITE_GOOGLE_REDIRECT_URI }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Deploy to S3
+        run: aws s3 sync build/ s3://${{ secrets.S3_BUCKET_NAME }} --delete
+
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/*"


### PR DESCRIPTION
## 요약

- Github actions과 S3, Cloudfront 사용해서 우리의 프론트 서버를 자동으로 배포하는 파이프라인을 구축한다.
- 우리의 코드를 main branch에 푸쉬하면, 자동으로 배포를 해주는 구조를 만든다.

## 변경 사항

- [x]  정적 페이지 저장용 S3 버킷 생성
    - [x]  정적 웹 사이트 호스팅 설정
- [x]  github actions로 CI/CD 구축
    - [x]  빌드 결과물을 S3에 업로드
- [x]  S3와 CloludFront 연동
    - [x]  원본 도메인에 이전에 생성한 S3버킷 선택
    - [ ]  Redirect HTTP to HTTPS 선택
    - [ ]  “기본값 루트 객체  - 선택사항"에만 index.html 입력 후 "배포 생성" 버튼 클릭
    - [ ]  오류 코드 정의
- [ ]  AWS에 배포 후, 제대로 동작하는지 통합 테스트 진행

## 체크리스트

- [ ] 이해하기 어려운 코드에는 주석을 추가했습니다  
- [ ] 관련 문서를 수정했습니다  
- [ ] 새로운 경고가 발생하지 않습니다  
- [ ] 수정한 기능 또는 추가한 기능에 대해 테스트를 작성했습니다  
- [ ] 의존성 있는 변경 사항이 병합 및 배포되었습니다

## 관련 이슈

<!-- 이 PR이 해결하는 관련 이슈나 버그가 있다면 연결해 주세요. 어떤 문제를 해결하는 코드인지 맥락을 제공합니다. -->

## 리뷰 반영 사항

<!-- PR리뷰 반형 사항 -->

<details>
<summary><strong>선택 항목 펼치기</strong></summary>

## 스크린샷

<!-- 시각적인 변경 사항이 있다면 스크린샷이나 GIF를 포함해 주세요. 리뷰어가 쉽게 이해할 수 있습니다. -->

## 테스트 방법

<!-- PR에서 수행한 변경 사항을 어떻게 테스트할 수 있는지 설명해 주세요. 리뷰어가 직접 확인할 수 있도록 돕습니다. -->

## 리뷰어 참고사항

<!-- 리뷰어에게 특별히 알려야 할 사항이나 고려할 점이 있다면 여기에 작성해 주세요. -->

</details>